### PR TITLE
Integrate MATSim results

### DIFF
--- a/assets/js/matsim.js
+++ b/assets/js/matsim.js
@@ -1,0 +1,50 @@
+(function(global){
+  'use strict';
+  async function fetchCsv(url){
+    const res = await fetch(url);
+    if(!res.ok) throw new Error('Failed to load '+url);
+    if(url.endsWith('.gz')){
+      if('DecompressionStream' in window && res.body){
+        const ds = new DecompressionStream('gzip');
+        const stream = res.body.pipeThrough(ds);
+        return await new Response(stream).text();
+      }else{
+        throw new Error('Gzip decompression not supported');
+      }
+    }
+    return await res.text();
+  }
+  function parseCsv(text){
+    const lines = text.trim().split(/\r?\n/);
+    const headers = lines.shift().split(',');
+    return lines.map(line => {
+      const cols = line.split(',');
+      const obj = {};
+      headers.forEach((h,i)=>{obj[h]=cols[i];});
+      return obj;
+    });
+  }
+  function computeTripMetrics(trips){
+    let total=0,count=0;
+    trips.forEach(t=>{
+      let dur = parseFloat(t.duration);
+      if(isNaN(dur)){
+        const dep=parseFloat(t.departureTime||t.departure_time||t.depTime);
+        const arr=parseFloat(t.arrivalTime||t.arrival_time||t.arrTime);
+        if(!isNaN(dep)&&!isNaN(arr)) dur = arr-dep;
+      }
+      if(!isNaN(dur)){
+        total += dur;
+        count++;
+      }
+    });
+    return {tripCount: trips.length, averageTravelTime: count?total/count:0};
+  }
+  global.MATSim = {
+    loadTripMetrics: async function(url){
+      const text = await fetchCsv(url);
+      const trips = parseCsv(text);
+      return computeTripMetrics(trips);
+    }
+  };
+})(this);

--- a/results.html
+++ b/results.html
@@ -414,12 +414,13 @@
 			<div class="l-fixed__bg js-fixed-close"></div>
 		</div>
 	</div>
-	<script src="assets/js/jszip.min.js"></script>
-	<script src="assets/js/leaflet/leaflet.js"></script>
-	<script src="assets/js/chart.min.js"></script>
-	<script src="assets/js/common.js"></script>
-	<script src="assets/js/map.js"></script>
-	<script src="assets/js/results.js"></script>
+        <script src="assets/js/jszip.min.js"></script>
+        <script src="assets/js/leaflet/leaflet.js"></script>
+        <script src="assets/js/chart.min.js"></script>
+        <script src="assets/js/common.js"></script>
+        <script src="assets/js/map.js"></script>
+        <script src="assets/js/matsim.js"></script>
+        <script src="assets/js/results.js"></script>
 	<script>
 		// 総合評価の初期化
 		const initialTotalDataA = [5, 4, 5, 4, 5, 2];
@@ -642,40 +643,50 @@
 		});
 		// 運用コストの初期化
 		const initialCostData = [300, 500];
-		const costChart = new Chart(document.getElementById('costChart'), {
-			type: 'bar',
-			data: {
-				labels: barLabels,
-				datasets: [{
-					data: initialCostData,
-					backgroundColor: barBgColor,
-				}]
-			},
-			options: {
-				scales: {
-					x: barX,
-					y: {
-						suggestedMax: 600,
-						ticks: {
-							stepSize: 50,
-							callback: function (value, index, ticks) {
-								return index < ticks.length - 1 ?
-									this.getLabelForValue(value) :
-									['(円)', this.getLabelForValue(value)];
-							}
-						},
-					}
-				},
-				plugins: {
-					legend: {
-						display: false,
-					}
-				},
-				maintainAspectRatio: false
-			}
-		});
+                const costChart = new Chart(document.getElementById('costChart'), {
+                        type: 'bar',
+                        data: {
+                                labels: barLabels,
+                                datasets: [{
+                                        data: initialCostData,
+                                        backgroundColor: barBgColor,
+                                }]
+                        },
+                        options: {
+                                scales: {
+                                        x: barX,
+                                        y: {
+                                                suggestedMax: 600,
+                                                ticks: {
+                                                        stepSize: 50,
+                                                        callback: function (value, index, ticks) {
+                                                                return index < ticks.length - 1 ?
+                                                                        this.getLabelForValue(value) :
+                                                                        ['(円)', this.getLabelForValue(value)];
+                                                        }
+                                                },
+                                        }
+                                },
+                                plugins: {
+                                        legend: {
+                                                display: false,
+                                        }
+                                },
+                                maintainAspectRatio: false
+                        }
+                });
 
-		const initialTripData = false;
+                // MATSim の結果を読み込み平均所要時間を更新
+                MATSim.loadTripMetrics('assets/data/0.trips.csv.gz')
+                        .then(result => {
+                                const time = Math.round(result.averageTravelTime);
+                                initialTimeData[1] = time;
+                                timeChart.data.datasets[0].data[1] = time;
+                                timeChart.update();
+                        })
+                        .catch(console.error);
+
+                const initialTripData = false;
 		const initialBCData = false;
 		function updateCharts(properties) {
 			// 総合評価の更新

--- a/results_graph.html
+++ b/results_graph.html
@@ -210,6 +210,7 @@
 <script src="assets/js/chart.min.js"></script>
 <script src="assets/js/common.js"></script>
 <script src="assets/js/map.js"></script>
+<script src="assets/js/matsim.js"></script>
 <script src="assets/js/results.js"></script>
 <script>
 // 総合評価の初期化
@@ -494,9 +495,19 @@ const costChart  = new Chart(document.getElementById('costChart'), {
 				display: false,
 			}
 		},
-		maintainAspectRatio: false
-	}
+                maintainAspectRatio: false
+        }
 });
+
+// MATSim results integration
+MATSim.loadTripMetrics('assets/data/0.trips.csv.gz')
+        .then(r => {
+                const time = Math.round(r.averageTravelTime);
+                initialTimeData[1] = time;
+                timeChart.data.datasets[0].data[1] = time;
+                timeChart.update();
+        })
+        .catch(console.error);
 let costChartData = null;
 document.querySelectorAll('input[name="chart06"]').forEach(button => {
 	button.addEventListener('change', () => {


### PR DESCRIPTION
## Summary
- add matsim.js helper to parse zipped CSV
- load matsim.js in results pages
- use MATSim trip metrics to update time charts

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685d2fe7341c832e88dfda18651d3200